### PR TITLE
Support for IntelliJ 2016.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-intellij-cucumber-scala 0.3.4
+intellij-cucumber-scala 0.3.5
 =======================
 
 [![Build Status](https://travis-ci.org/danielwegener/intellij-cucumber-scala.svg)](https://travis-ci.org/danielwegener/intellij-cucumber-scala)

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ import sbt.Keys._
 
 name :=  "Cucumber for Scala"
 normalizedName :=  "intellij-cucumber-scala"
-version := "0.3.4"
+version := "0.3.5"
 scalaVersion :=  "2.11.8"
 
-lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/files/1347/24700/scala-intellij-bin-3.0.0.zip"))
+lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/files/1347/27087/scala-intellij-bin-2016.2.0.zip"))
 lazy val `cucumber-java` = IdeaPlugin.Zip("cucumber-java", url("https://plugins.jetbrains.com/files/7212/22138/cucumber-java.zip"))
 lazy val cucumber = IdeaPlugin.Zip("cucumber", url("https://plugins.jetbrains.com/files/7211/22137/cucumber.zip"))
 
@@ -19,7 +19,7 @@ lazy val `cucumber-scala` = project.in(file( "."))
     javacOptions in Global ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions in Global += "-target:jvm-1.6",
     ideaExternalPlugins ++= Seq(`scala-plugin`, cucumber, `cucumber-java`),
-    ideaBuild in ThisBuild := "145.258.11",
+    ideaBuild in ThisBuild := "162.1121.10",
     ideaEdition in ThisBuild := IdeaEdition.Community,
     fork in Test := true,
     parallelExecution := true

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
 <idea-plugin version="2">
     <id>com.github.danielwegener.cucumber-scala</id>
     <name>Cucumber for Scala</name>
-    <version>0.3.4</version>
+    <version>0.3.5</version>
     <vendor email="daniel@wegener.me" url="http://daniel.wegener.me">Daniel Wegener</vendor>
 
     <description><![CDATA[
@@ -22,11 +22,12 @@
       0.3.2: Release for IntelliJ 15.0 (unchanged functionality)
       0.3.3: Release for IntelliJ 15.0.2, scala-plugin 2.0.4, support inheriting step definitions from traits (#16)
       0.3.4: Release for IntelliJ 2016.1 (scala-plugin 3.0.0)
+      0.3.5: Release for IntelliJ 2016.2 (scala-plugin 2016.2.0)
     ]]>
     </change-notes>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Build+Number+Ranges for description -->
-    <idea-version since-build="145.258" until-build="146.0"/>
+    <idea-version since-build="162.1121" until-build="163.0"/>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
I fixed #21. 
IntelliJ 2016.2(162.1121.32) clean version does not have `cucumber` plugin, so I followed below steps.
1. Install `Cucumber for Java` plugin which installs `cucumber` plugin together.
2. Install our `Cucumber for Scala 0.3.5` jar file.
3. Uninstall `Cucumber for Java` plugin.
Works fine on my local machine. :smile: 