### PR TITLE
fix dependency on new plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbt.Keys._
 
 name :=  "Cucumber for Scala"
 normalizedName :=  "intellij-cucumber-scala"
-version := "2017.1.15"
+version := "2017.1.2"
 scalaVersion :=  "2.11.8"
 
 lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/files/1347/33637/scala-intellij-bin-2017.1.15.zip"))

--- a/build.sbt
+++ b/build.sbt
@@ -3,10 +3,10 @@ import sbt.Keys._
 
 name :=  "Cucumber for Scala"
 normalizedName :=  "intellij-cucumber-scala"
-version := "2017.1.1"
+version := "2017.1.15"
 scalaVersion :=  "2.11.8"
 
-lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/files/1347/32268/scala-intellij-bin-2017.1.8.zip"))
+lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/files/1347/33637/scala-intellij-bin-2017.1.15.zip"))
 lazy val `cucumber-java` = IdeaPlugin.Zip("cucumber-java", url("https://plugins.jetbrains.com/files/7212/30792/cucumber-java.zip"))
 lazy val gherkin = IdeaPlugin.Zip("gherkin", url("https://plugins.jetbrains.com/files/7211/29344/cucumber.zip"))
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
 <idea-plugin version="2">
     <id>com.github.danielwegener.cucumber-scala</id>
     <name>Cucumber for Scala</name>
-    <version>2017.1.1</version>
+    <version>2017.1.2</version>
     <vendor email="daniel@wegener.me" url="http://daniel.wegener.me">Daniel Wegener</vendor>
 
     <description><![CDATA[
@@ -26,6 +26,7 @@
       0.3.6: Release for IntelliJ 2016.3
       0.3.7: Release for IntelliJ 2016.3 (fix renamed gherkin dependency)
       2017.1.1: Release for IntelliJ 2017.1 (scala-plugin 2017.1.8)
+      2017.1.2: fix compatibility with external changes in scala plugin
     ]]>
     </change-notes>
 

--- a/src/main/scala/com/github/danielwegener/intellij/cucumber/scala/CucumberScalaExtension.scala
+++ b/src/main/scala/com/github/danielwegener/intellij/cucumber/scala/CucumberScalaExtension.scala
@@ -45,7 +45,7 @@ class CucumberScalaExtension extends AbstractCucumberExtension {
   }
 
   @NotNull
-  override val getStepFileType: BDDFrameworkType = new BDDFrameworkType(ScalaFileType.SCALA_FILE_TYPE)
+  override val getStepFileType: BDDFrameworkType = new BDDFrameworkType(ScalaFileType.INSTANCE)
 
   @NotNull
   override def getStepDefinitionCreator: StepDefinitionCreator = throw new UnsupportedOperationException("You cannot automatically create Steps yet.")
@@ -66,7 +66,7 @@ class CucumberScalaExtension extends AbstractCucumberExtension {
       scalaDslInheritingClass <- psi.stubs.util.ScalaStubsUtil.getClassInheritors(cucumberDslClass, dependenciesScope).collect { case sc: ScClass => sc; case sct: ScTrait => sct }
       glueCodeClass <- classAndItsInheritors(scalaDslInheritingClass, dependenciesScope)
       scConstructorBody <- glueCodeClass.extendsBlock.templateBody.toSeq
-      outerMethodCall <- scConstructorBody.children.collect { case mc: ScMethodCall => mc }
+      outerMethodCall <- scConstructorBody.getChildren.collect { case mc: ScMethodCall => mc }
     } yield new ScalaStepDefinition(outerMethodCall)
 
     JavaConversions.seqAsJavaList(stepDefs)

--- a/src/main/scala/com/github/danielwegener/intellij/cucumber/scala/steps/ScalaStepDefinition.scala
+++ b/src/main/scala/com/github/danielwegener/intellij/cucumber/scala/steps/ScalaStepDefinition.scala
@@ -20,7 +20,7 @@ class ScalaStepDefinition(scMethod: ScMethodCall) extends AbstractStepDefinition
     val r = for {
       // WHEN("""regexp""") { (arg0:Int, arg1:String) <-- we want to match these
       arg <- scMethod.args.exprs
-      parentheses <- arg.children
+      parentheses <- arg.getChildren
     } yield (arg, parentheses)
 
     LOG.info(r.toString)


### PR DESCRIPTION
Dependency scala plugin can be found here 
https://github.com/pbyrne84/scala-cucumber-deps
(copied from the plugin dir of the ide)

https://intellij-support.jetbrains.com/hc/en-us/articles/206544519-Directories-used-by-the-IDE-to-store-settings-caches-plugins-and-logs

delete the automatically downloaded zip in 
intellij-cucumber-scala/idea/171.3566.24/externalPlugins/scala-plugin.zip
and replace with this one https://github.com/pbyrne84/scala-cucumber-deps/blob/master/scala-plugin.zip  (or build your own from your own plugin dir)

remove old scala-plugin folder and unzip this one instead

ScalaFileType.INSTANCE should exist not ScalaFileType.SCALA_FILE_TYPE

I bumped the number up to be mininumish of release version
