### PR TITLE
Make 2018.1 compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,69 @@ Now you can build this plugin with `sbt package`
 
 To start an IDE with the plugin installed in the example project just run `sbt "runIdea example"` (_todo: does not work yet_)
 
+
+# Using a run configuration
+(set it to 'single instance only' so it kills the current version when restarting)
+
+This is all reverse engineered (in reality playing a game of spot the difference)
+with the scala plugin run configurations.
+
+https://github.com/JetBrains/intellij-scala/blob/8030aef21f8f726796f7230d5f29669e35ebeec9/.idea/runConfigurations/IDEA.xml#L7
+
+It is quite important that scala library does not get added to the classpath etc. If there are
+problems run the scala plugin by
+
+1. Checkout https://github.com/JetBrains/intellij-scala
+2. Open in Intellij
+3. git checkout idea as that will demangle the run configuration so it can be ran easily
+
+When running a configuration to analyse the output of the run window replace : with new lines
+so it is diffable.
+
+## Main class
+```
+com.intellij.idea.Main
+```
+
+## VM Options (Note this is using build id 181.4445.78)
+``` 
+-Xmx800m
+-XX:ReservedCodeCacheSize=240m
+-XX:+HeapDumpOnOutOfMemoryError
+-ea
+-Didea.is.internal=true
+-Didea.debug.mode=true
+-Dapple.laf.useScreenMenuBar=true
+-Dplugin.path=target/scala-2.12/intellij-cucumber-scala_2.12-2018.1.0.jar
+-Didea.platform.prefix=Idea
+-Didea.system.path=idea/system
+-Didea.config.path=idea/config
+-Didea.plugins.path=idea/181.4445.78/externalPlugins
+```
+
+If system and config outside of extraction directory then it is easier to
+purge when a new version is out. You don't have to go through the whole
+running for the first time wizard.
+
+
+## Use classpath of module
+```
+runner-cucumber-scala-idea
+```
+
+## Optional but useful
+Under run configuration create additional before launch external tool
+1. Name: sbt_package
+2. Program: sbt
+3. Arguments: package
+
+This will mean that a fresh plugin jar is created each time the test community
+edition launches from the run configuration.
+
 # Publishing
 
 
-1. Add your credentials to `ideaPublishSettings` in `build.sbt` (make sure to not check them in!) 
+1. Add your credentials to `ideaPublishSettings` in `build.sbt` (make sure to not check them in!)
 2 run `sbt publishPlugin`
 
 # License

--- a/build.sbt
+++ b/build.sbt
@@ -3,26 +3,50 @@ import sbt.Keys._
 
 name :=  "Cucumber for Scala"
 normalizedName :=  "intellij-cucumber-scala"
-version := "2017.3.1"
-scalaVersion :=  "2.12.4"
+version := "2018.1.0"
+scalaVersion :=  "2.12.3"
 
-lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/plugin/download?updateId=41523"))
-lazy val `cucumber-java` = IdeaPlugin.Zip("cucumber-java", url("https://plugins.jetbrains.com/plugin/download?updateId=39749"))
-lazy val gherkin = IdeaPlugin.Zip("gherkin", url("https://plugins.jetbrains.com/plugin/download?updateId=39748"))
+lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/plugin/download?updateId=45268"))
+lazy val `cucumber-java` = IdeaPlugin.Zip("cucumber-java", url("https://plugins.jetbrains.com/plugin/download?updateId=43535"))
+lazy val gherkin = IdeaPlugin.Zip("gherkin", url("https://plugins.jetbrains.com/plugin/download?updateId=43534"))
+lazy val ideaBuildNumber  = "181.4445.78"
 
 lazy val `cucumber-scala` = project.in(file( "."))
   .enablePlugins(SbtIdeaPlugin)
   .enablePlugins(SbtIdeaPluginPimps)
   .settings(scalariformSettings)
   .settings(
-    autoScalaLibrary := false,
+    scalaVersion := "2.12.3",
     javacOptions in Global ++= Seq("-source", "1.6", "-target", "1.6"),
     scalacOptions in Global += "-target:jvm-1.6",
     ideaExternalPlugins ++= Seq(`scala-plugin`, gherkin, `cucumber-java`),
     // check https://s3-eu-west-1.amazonaws.com/intellij-releases/ for valid builds
-    ideaBuild in ThisBuild := "173.3942.27",
+    ideaBuild in ThisBuild := ideaBuildNumber,
     ideaEdition in ThisBuild := IdeaEdition.Community,
     ideaPublishSettings := PublishSettings(pluginId = "com.github.danielwegener.cucumber-scala", username = "", password = "", channel = None),
     fork in Test := true,
     parallelExecution := true
 )
+
+lazy val `runner-cucumber-scala-idea`  = project.in(file(s"idea"))
+  .settings(
+      autoScalaLibrary := false,
+      unmanagedBase := baseDirectory.value / s"$ideaBuildNumber/lib",
+      fork in run := true,
+      mainClass in(Compile, run) := Some("com.intellij.idea.Main"),
+      javaOptions in run ++= Seq(
+          "-Xmx800m",
+          "-XX:ReservedCodeCacheSize=64m",
+          "-XX:MaxPermSize=250m",
+          "-XX:+HeapDumpOnOutOfMemoryError",
+          "-ea",
+          "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005",
+          "-Didea.is.internal=true",
+          "-Didea.debug.mode=true",
+          s"-Didea.plugins.path=idea/$ideaBuildNumber/externalPlugins",
+          s"-Didea.config.path=idea/$ideaBuildNumber/system",
+          "-Dapple.laf.useScreenMenuBar=true",
+          "-Didea.ProcessCanceledException=disabled"
+      )
+  )
+

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
 <idea-plugin>
     <id>com.github.danielwegener.cucumber-scala</id>
     <name>Cucumber for Scala</name>
-    <version>2017.3.1</version>
+    <version>2018.1.0</version>
     <vendor email="daniel@wegener.me" url="http://daniel.wegener.me">Daniel Wegener</vendor>
 
     <description><![CDATA[
@@ -35,7 +35,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="173.3942.27" until-build="174.0"/>
+    <idea-version since-build="173.3942.27" until-build="182.0"/>
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
Make 2018.1 compatible
Create ability to have run configuration to ease debugging

The runIdea stuff is borked (ignores all the java options etc)

I created a module that generates a classpath so run configurations can be used instead (like the scala plugin) uses as it is more user friendly when an "sbt package" is added to the process. Also the classpath is visible when running so running the actual scala plugin can be used as reference. This stuff is not really documented.

This actually makes stuff a lot easier as the debugger from intellij now works easily and last used run ("ctrl r" on osx on my keyboard) shuts the application, packages a new one and then reopens etc. 

I moved user config and system to be in root of idea so things like user settings are not lost if version changes etc. 
