### PR TITLE
update version numbers for 2018 2 0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,13 +3,13 @@ import sbt.Keys._
 
 name :=  "Cucumber for Scala"
 normalizedName :=  "intellij-cucumber-scala"
-version := "2018.1.0"
+version := "2018.2.0"
 scalaVersion :=  "2.12.4"
 
-lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/plugin/download?updateId=44474"))
+lazy val `scala-plugin` = IdeaPlugin.Zip("scala-plugin", url("https://plugins.jetbrains.com/plugin/download?updateId=45268"))
 lazy val `cucumber-java` = IdeaPlugin.Zip("cucumber-java", url("https://plugins.jetbrains.com/plugin/download?updateId=43535"))
 lazy val gherkin = IdeaPlugin.Zip("gherkin", url("https://plugins.jetbrains.com/plugin/download?updateId=43534"))
-lazy val ideaBuildNumber  = "181.4445.78"
+lazy val ideaBuildNumber  = "182.3684.101"
 
 lazy val `cucumber-scala` = project.in(file( "."))
   .enablePlugins(SbtIdeaPlugin)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -3,7 +3,7 @@
 <idea-plugin>
     <id>com.github.danielwegener.cucumber-scala</id>
     <name>Cucumber for Scala</name>
-    <version>2018.1.0</version>
+    <version>2018.2.0</version>
     <vendor email="daniel@wegener.me" url="http://daniel.wegener.me">Daniel Wegener</vendor>
 
     <description><![CDATA[
@@ -35,7 +35,7 @@
     </change-notes>
 
     <!-- please see http://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/build_number_ranges.html for description -->
-    <idea-version since-build="173.3942.27" until-build="182.0"/>
+    <idea-version since-build="182.0" />
 
     <!-- please see http://confluence.jetbrains.com/display/IDEADEV/Plugin+Compatibility+with+IntelliJ+Platform+Products
          on how to target different products -->


### PR DESCRIPTION
remove until limit though may be an idea not to version jar so it gets replaced when updated instead of the maybe manual deletion it will require now due to the limit removed.

If you prefer to do that let me know. This way you might night get annoyed again until a shift to Scala 2.13